### PR TITLE
Add h5py to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ keras==2.2.4
 simplejson==3.16.0
 xeger==0.3.4
 numpy==1.14.5
+h5py==2.10.0


### PR DESCRIPTION
A newer version of `h5py` is brought in that is not compatible with this project

Explicitly setting the version so it will work out of the box.